### PR TITLE
Fix/timestamp-test

### DIFF
--- a/macros/test_in_past.sql
+++ b/macros/test_in_past.sql
@@ -2,6 +2,6 @@
 
     select *
     from {{ model }}
-    where (cast({{ column_name }} as timestamp) >= current_timestamp() and  {{ column_name }} is not null)
+    where (cast({{ column_name }} as timestamp) >= convert_timezone('UTC', current_timestamp()) and  {{ column_name }} is not null)
 
 {% endtest %}


### PR DESCRIPTION
Snowflake's default timezone is not UTC, so tests that check for any future events fails when they have happened in a different timezone. This PR fixes this problem for snowflake connections, but errors for BigQuery. There is a to do to add a platform agnostic function for changing timezones.