### PR TITLE
Fix/timestamp-test-timezone

### DIFF
--- a/macros/test_in_past.sql
+++ b/macros/test_in_past.sql
@@ -2,6 +2,6 @@
 
     select *
     from {{ model }}
-    where (cast({{ column_name }} as timestamp) >= convert_timezone('UTC', current_timestamp()) and  {{ column_name }} is not null)
+    where (cast({{ column_name }} as timestamp) >= convert_timezone('UTC', current_timestamp())::timestamp_ntz and  {{ column_name }} is not null)
 
 {% endtest %}


### PR DESCRIPTION
Timezones were not being tested correctly due to differences in the timestamp timezone types - this has been fixed for snowflake destinations, but needs making agnostic.