### PR TITLE
hotfix/remove-unneeded-dbt-utils

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,0 @@
-packages:
-  - package: dbt-labs/dbt_utils
-    version: 1.0.0


### PR DESCRIPTION
This PR removes the dependency on dbt-utils that was actual not required since the migration of a number of key functions into native dbt.