### PR TITLE
Better handle PRs raised by Dependabot

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install python deps
         id: install-python-deps
         run: |
-          poetry install
+          poetry install --no-root
 
       - name: Install dbt deps
         id: install-dbt-deps

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -21,11 +21,19 @@ jobs:
       SNOWFLAKE_DATABASE_CI: DBT_PACKAGE_CI
       SNOWFLAKE_ROLE_CI: PACKAGE_CI_ROLE
       SNOWFLAKE_WAREHOUSE_CI: PACKAGE_CI_WH
-      SNOWFLAKE_SCHEMA_CI: DBT_CI_${{github.event.number}}_${{ github.actor }} # Creates a unique schema for each PR
     steps:
       - name: Checkout branch
         id: checkout-branch
         uses: actions/checkout@v3
+
+      - name: Set schema name
+        id: set-schema-name
+        run: |
+          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+            echo "schema_name=dependabot" >> $GITHUB_OUTPUT
+          else
+            echo "schema_name=${{ github.actor }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install Poetry
         id: install-poetry
@@ -51,10 +59,14 @@ jobs:
 
       - name: Check dbt compiles and CI Profiles work
         id: check-dbt-ci-profiles-work
+        env:
+          SNOWFLAKE_SCHEMA_CI: DBT_CI_${{github.event.number}}_${{ steps.set-schema-name.outputs.schema_name }}
         run: |
           poetry run dbt debug --target snowflake-ci
 
       - name: dbt build on Snowflake
         id: dbt-build-snowflake
+        env:
+          SNOWFLAKE_SCHEMA_CI: DBT_CI_${{github.event.number}}_${{ steps.set-schema-name.outputs.schema_name }}
         run: |
           poetry run dbt build --full-refresh --target snowflake-ci


### PR DESCRIPTION
## Summary

Better handle the name of the schema created by PRs raised by Dependabot.

## Details

We run dbt in CI on PRs and use the name of the git author in the newly created schema name. PRs raised by Dependabot have an author name of `dependabot[bot]` which is invalid for use in a schema name.

It's also worth mentioning here that Dependabot can't read Action secrets stored in the repo, so the repo secrets _also_ need to be added to the Dependabot secrets stored in the repo. More details at:

- https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

---

Similar PRs:

- https://github.com/TasmanAnalytics/tasman-dbt-revenuecat/pull/12
- https://github.com/TasmanAnalytics/tasman-dbt-package-template/pull/1
- https://github.com/TasmanAnalytics/tasman-dbt-utils/pull/23