### PR TITLE
refactor: standardize DATEADD to use dbt cross-database macro

### DIFF
--- a/models/schema.yml
+++ b/models/schema.yml
@@ -186,48 +186,48 @@ models:
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
           - unique:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
 
       - name: conversion_user_id
         description: "Identifier for the user associated with the conversion"
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
 
       - name: conversion_event_id
         description: "Identifer that defines a unique conversion event."
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
 
       - name: conversion_timestamp
         description: "The timestamp when the conversion event happened."
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
           - in_past:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
 
       - name: model_id
         description: "Identifer that specifies the attribution model that the attribution relates to."
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
 
       - name: conversion_category
         description: "The category of conversion event, as defined in the conversion rules seed."
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
 
   - name: tasman_mta__filtered_touch_events
     description: "This model applies the touch rules seed to the model defined in the 'touches_model' variable with the project file."
@@ -237,45 +237,45 @@ models:
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
           - unique:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
 
       - name: touch_user_id
         description: "Identifier for the user associated with the touch"
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
 
       - name: touch_event_id
         description: "Identifer that defines a unique touch event."
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
 
       - name: touch_timestamp
         description: "The timestamp when the touch event happened."
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
           - in_past:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
 
       - name: model_id
         description: "Identifer that specifies the attribution model that the attribution relates to."
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"
 
       - name: touch_category
         description: "The category of the touch, as defined in the touch rules seed."
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= {{ dateadd('hour', -var('test_hours'), current_timestamp()) }}"


### PR DESCRIPTION
Replace warehouse-specific DATEADD syntax with [dbt's cross-database dateadd](https://docs.getdbt.com/sql-reference/dateadd#:~:text=The%20DATEADD%20function%20in%20SQL,from%20a%20given%20start%20date) macro in test configurations for improved portability.

Changes:
- Update 16 test where clauses in models/schema.yml
- Convert DATEADD(HOUR, -X, timestamp) to {{ dateadd('hour', -X, timestamp) }}
- Ensures compatibility across different data warehouses (BigQuery, Snowflake, etc.)

Affected models:
- tasman_mta__attributed_conversions
- tasman_mta__filtered_touch_events