### PR TITLE
Refactor/custom test filter

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -37,6 +37,6 @@ vars:
     attribution_rules: "{{ ref('attribution_rules') }}"
     conversion_shares: "{{ ref('conversion_shares') }}"
     attribution_windows: "{{ ref('attribution_windows') }}"
-    test_hours: "36"
+    test_hours: 36
     snowflake_prod_warehouse: ""
     snowflake_dev_warehouse: ""

--- a/macros/get_where_subquery.sql
+++ b/macros/get_where_subquery.sql
@@ -2,8 +2,8 @@
     {% set where = config.get('where') %}
     {% if where %}
         {% if '__test_hours_ago__' in where %}
-            {% set hours = var('test_hours') %}
-            {% set n_hours_ago = "cast(" ~ dbt.dateadd('hour', hours * -1, dbt.current_timestamp()) ~ " as timestamp)" %}
+            {% set hours = var('test_hours') | int %}
+            {% set n_hours_ago = "cast(" ~ dbt.dateadd('hour', (-1 * hours), dbt.current_timestamp()) ~ " as timestamp)" %}
             {% set where = where | replace('__test_hours_ago__', n_hours_ago) %}
         {% endif %}
         {%- set filtered -%}

--- a/macros/get_where_subquery.sql
+++ b/macros/get_where_subquery.sql
@@ -1,0 +1,16 @@
+{% macro get_where_subquery(relation) -%}
+    {% set where = config.get('where') %}
+    {% if where %}
+        {% if '__test_hours_ago__' in where %}
+            {% set hours = var('test_hours') %}
+            {% set n_hours_ago = dbt.dateadd('hour', -hours, dbt.current_timestamp()) %}
+            {% set where = where | replace('__test_hours_ago__', n_hours_ago) %}
+        {% endif %}
+        {%- set filtered -%}
+            (select * from {{ relation }} where {{ where }}) dbt_subquery
+        {%- endset -%}
+        {% do return(filtered) %}
+    {%- else -%}
+        {% do return(relation) %}
+    {%- endif -%}
+{%- endmacro %}

--- a/macros/get_where_subquery.sql
+++ b/macros/get_where_subquery.sql
@@ -3,7 +3,7 @@
     {% if where %}
         {% if '__test_hours_ago__' in where %}
             {% set hours = var('test_hours') %}
-            {% set n_hours_ago = "cast(" ~ dbt.dateadd('hour', -hours, dbt.current_timestamp()) ~ " as timestamp)" %}
+            {% set n_hours_ago = "cast(" ~ dbt.dateadd('hour', hours * -1, dbt.current_timestamp()) ~ " as timestamp)" %}
             {% set where = where | replace('__test_hours_ago__', n_hours_ago) %}
         {% endif %}
         {%- set filtered -%}

--- a/macros/get_where_subquery.sql
+++ b/macros/get_where_subquery.sql
@@ -3,7 +3,7 @@
     {% if where %}
         {% if '__test_hours_ago__' in where %}
             {% set hours = var('test_hours') %}
-            {% set n_hours_ago = dbt.dateadd('hour', -hours, dbt.current_timestamp()) %}
+            {% set n_hours_ago = "cast(" ~ dbt.dateadd('hour', -hours, dbt.current_timestamp()) ~ " as timestamp)" %}
             {% set where = where | replace('__test_hours_ago__', n_hours_ago) %}
         {% endif %}
         {%- set filtered -%}

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -186,48 +186,48 @@ models:
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= __test_hours_ago__"
           - unique:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= __test_hours_ago__"
 
       - name: conversion_user_id
         description: "Identifier for the user associated with the conversion"
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= __test_hours_ago__"
 
       - name: conversion_event_id
         description: "Identifer that defines a unique conversion event."
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= __test_hours_ago__"
 
       - name: conversion_timestamp
         description: "The timestamp when the conversion event happened."
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= __test_hours_ago__"
           - in_past:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= __test_hours_ago__"
 
       - name: model_id
         description: "Identifer that specifies the attribution model that the attribution relates to."
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= __test_hours_ago__"
 
       - name: conversion_category
         description: "The category of conversion event, as defined in the conversion rules seed."
         tests:
           - not_null:
               config:
-                where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "conversion_timestamp >= __test_hours_ago__"
 
   - name: tasman_mta__filtered_touch_events
     description: "This model applies the touch rules seed to the model defined in the 'touches_model' variable with the project file."
@@ -237,45 +237,45 @@ models:
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= __test_hours_ago__"
           - unique:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= __test_hours_ago__"
 
       - name: touch_user_id
         description: "Identifier for the user associated with the touch"
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= __test_hours_ago__"
 
       - name: touch_event_id
         description: "Identifer that defines a unique touch event."
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= __test_hours_ago__"
 
       - name: touch_timestamp
         description: "The timestamp when the touch event happened."
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= __test_hours_ago__"
           - in_past:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= __test_hours_ago__"
 
       - name: model_id
         description: "Identifer that specifies the attribution model that the attribution relates to."
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= __test_hours_ago__"
 
       - name: touch_category
         description: "The category of the touch, as defined in the touch rules seed."
         tests:
           - not_null:
               config:
-                where: "touch_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
+                where: "touch_timestamp >= __test_hours_ago__"


### PR DESCRIPTION
# Fix `where` config for BigQuery compatibility

## Summary

Replaces Snowflake-specific `DATEADD()` syntax in data test `where` configs with a cross-platform approach using a custom `get_where_subquery` macro override. This enables the dbt project to run tests on both Snowflake and BigQuery without SQL dialect errors.

## Problem

The `where` configs on data tests in `models/schema.yml` used `DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())`, which is Snowflake/SQL Server syntax and not supported in BigQuery. This caused test failures when attempting to run the project on BigQuery.

Additionally, dbt YAML `where` configs only support `{{ var() }}` and `{{ env_var() }}` - they cannot use arbitrary macros like `{{ dbt.dateadd() }}` directly.

## Solution

### 1. Created `macros/get_where_subquery.sql`

Added a macro override that intercepts dbt's default `get_where_subquery` behavior:
- Detects the `__test_hours_ago__` placeholder in any `where` config
- Replaces it at runtime with `dbt.dateadd()`, which dispatches correctly per adapter
- Wraps the result in a `CAST()` for explicit BigQuery timestamp compatibility
- Falls back to default behavior for tests without the placeholder

```sql
{% macro get_where_subquery(relation) -%}
    {% set where = config.get('where') %}
    {% if where %}
        {% if '__test_hours_ago__' in where %}
            {% set hours = var('test_hours') %}
            {% set n_hours_ago = "cast(" ~ dbt.dateadd('hour', -hours, dbt.current_timestamp()) ~ " as timestamp)" %}
            {% set where = where | replace('__test_hours_ago__', n_hours_ago) %}
        {% endif %}
        {%- set filtered -%}
            (select * from {{ relation }} where {{ where }}) dbt_subquery
        {%- endset -%}
        {% do return(filtered) %}
    {%- else -%}
        {% do return(relation) %}
    {%- endif -%}
{%- endmacro %}
```

### 2. Updated `models/schema.yml`

Replaced **16 instances** of Snowflake-specific syntax with the placeholder pattern:

**Before:**
```yaml
where: "conversion_timestamp >= DATEADD(HOUR, -{{ var('test_hours') }}, current_timestamp())"
```

**After:**
```yaml
where: "conversion_timestamp >= __test_hours_ago__"
```

Affected models:
- `tasman_mta__filtered_conversion_events` (8 tests)
- `tasman_mta__filtered_touch_events` (8 tests)

### 3. Fixed `test_hours` variable type

Changed `test_hours` from string `"36"` to integer `36` in `integration_tests/dbt_project.yml` to prevent type errors in arithmetic operations.
