### PR TITLE
fix: adding spec to surrogate key to account to multi-spec touches

### DIFF
--- a/models/schema.yml
+++ b/models/schema.yml
@@ -7,7 +7,7 @@ models:
     description: "This model contains both attributed and unattributed conversion events, along with the metadata describing the attribution. There is at least 1 row per conversion per model."
     columns:
       - name: surrogate_key
-        description: "A unique key for the table, generated from the hash of the model ID, touch event ID and conversion event ID"
+        description: "A unique key for the table, generated from the hash of the model ID, touch event ID, conversion event ID, and attribution spec"
         tests:
           - not_null
           - unique
@@ -93,7 +93,7 @@ models:
     description: "This model contains all touches that have been successfully attributed to a conversion. There is at least 1 row per conversion per model"
     columns:
       - name: surrogate_key
-        description: "A unique key for the table, generated from the hash of the model ID and touch event ID"
+        description: "A unique key for the table, generated from the hash of the model ID, touch event ID, and attribution spec"
         tests:
           - not_null
           - unique
@@ -233,7 +233,7 @@ models:
     description: "This model applies the touch rules seed to the model defined in the 'touches_model' variable with the project file."
     columns:
       - name: surrogate_key
-        description: "A unique key for the table, generated from the hash of the model ID and touch event ID"
+        description: "A unique key for the table, generated from the hash of the model ID, touch event ID, and attribution spec"
         tests:
           - not_null:
               config:

--- a/models/tasman_mta__attributed_conversions.sql
+++ b/models/tasman_mta__attributed_conversions.sql
@@ -23,7 +23,8 @@ joined_conversion_events as (
             'attributed_touches.model_id',
             'conversion_events.model_id',
             'attributed_touches.touch_event_id',
-            'conversion_events.conversion_event_id'
+            'conversion_events.conversion_event_id',
+            'attributed_touches.spec'
             ]) }} as surrogate_key,
         conversion_events.conversion_user_id,
         conversion_events.conversion_event_id,

--- a/models/tasman_mta__attributed_touches.sql
+++ b/models/tasman_mta__attributed_touches.sql
@@ -311,7 +311,8 @@ attributed_events as (
     select
         {{ generate_surrogate_key([
             'touch_events.model_id',
-            'touch_events.touch_event_id'
+            'touch_events.touch_event_id',
+            'share_attribution.spec'
             ]) }} as surrogate_key,
         touch_events.*,
         share_attribution.spec,


### PR DESCRIPTION
Fix surrogate key grain for attributed touches and conversions

The surrogate_key in tasman_mta__attributed_touches and tasman_mta__attributed_conversions was missing spec as a component, causing unique test failures in projects that use multiple attribution specs per model (e.g. W-shaped models where a single touch can match both first-touch and last-touch specs simultaneously).

Added spec to the surrogate key in both models and updated the column descriptions in schema.yml to reflect the correct grain.